### PR TITLE
Typo on the Homepage

### DIFF
--- a/view/home.ftl.html
+++ b/view/home.ftl.html
@@ -260,7 +260,7 @@ User profile page on ${r"${deviceName}"}
 </code>
                 <p class="text-center"><a href="/docs/reference-galen-test-suite-syntax/"  target="__blank" class="btn btn-primary home-button home-button-on-dark" role="button">See more</a></p>
                 <p class="home-description text-center">
-                    Standard suites are easy for a quick start but still give you a lot of power. You can select different browser like Firefox, Chrome, Internet Explore or switch your tests to Selenium Grid. In case the page is not easy accessible you can either inject custom JavaScript on the client-side or run a JavaScript action on a test side so that you can prepare your page for a layout check
+                    Standard suites are easy for a quick start but still give you a lot of power. You can select different browser like Firefox, Chrome, Internet Explorer or switch your tests to Selenium Grid. In case the page is not easy accessible you can either inject custom JavaScript on the client-side or run a JavaScript action on a test side so that you can prepare your page for a layout check
                 </p>
             </div>
             <div class="col-sm-6 col-lg-6">


### PR DESCRIPTION
Someone was just showing this tool and I spotted this one:

`Internet Explore` -> `Internet Explorer`