### PR TITLE
fixes missing reference to the pages list field

### DIFF
--- a/db/docs/reference-galenpages-javascript-api.blogix
+++ b/db/docs/reference-galenpages-javascript-api.blogix
@@ -108,8 +108,8 @@ this.MyNotesPage = $page("My notes page", {
 
 var myNotesPage = new MyNotesPage(driver);
 
-for (var i = 0; i < myNotesPage.size(); i++) {
-  System.out.println(myNotesPage.get(i).title.getText());
+for (var i = 0; i < myNotesPage.myNotes.size(); i++) {
+  System.out.println(myNotesPage.myNotes.get(i).title.getText());
 }
 $$
 


### PR DESCRIPTION
`myNotes` field name was missing in the `$list` example.